### PR TITLE
Avoid type error if array not passed

### DIFF
--- a/bundle/Form/Type/FieldType/FieldValueTransformer.php
+++ b/bundle/Form/Type/FieldType/FieldValueTransformer.php
@@ -47,7 +47,7 @@ final class FieldValueTransformer implements DataTransformerInterface
             return $this->fieldType->getEmptyValue();
         }
 
-        $value['keywords'] = explode(',', (string)$value['keywords']);
+        $value['keywords'] = explode(',', $value['keywords'] ?? '');
         $value['sitemap_use'] = $value['sitemap_use'] ? '1' : '0';
 
         return $this->fieldType->acceptValue($value);

--- a/bundle/Form/Type/FieldType/FieldValueTransformer.php
+++ b/bundle/Form/Type/FieldType/FieldValueTransformer.php
@@ -47,7 +47,7 @@ final class FieldValueTransformer implements DataTransformerInterface
             return $this->fieldType->getEmptyValue();
         }
 
-        $value['keywords'] = explode(',', $value['keywords']);
+        $value['keywords'] = explode(',', (string)$value['keywords']);
         $value['sitemap_use'] = $value['sitemap_use'] ? '1' : '0';
 
         return $this->fieldType->acceptValue($value);


### PR DESCRIPTION
php throws error if $value['keywords'] is null